### PR TITLE
fix error position so it can be ignored

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,9 +1,10 @@
+
 module.exports = (fn, ctx) => (...args) =>
   new Promise((resolve, reject) =>
     process.nextTick(() =>
       fn.call(ctx, ...args, (err, ...values) => {
-        if (err) return resolve([err])
-        return resolve([null, ...values])
+        if (err) return resolve([null, err])
+        return resolve([...values, null])
       })
     )
   )

--- a/test.js
+++ b/test.js
@@ -14,12 +14,12 @@ const fn = asde(foo)
 
 async function main () {
   {
-    const [err, n] = await fn(50)
+    const [ n, err] = await fn(50)
     assert(err, 'should return an error')
   }
 
   {
-    const [err, n] = await fn(150)
+    const [n, err] = await fn(150)
     assert(!err, 'no error when callback provides null as first arg')
     assert(n === 150, 'value returned and destructured')
   }


### PR DESCRIPTION
Because maybe you are just prototyping and you don't want to declare [err, response] every time. 